### PR TITLE
Label workflow maintenance

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -6,7 +6,7 @@ on:
       - main
   workflow_dispatch:
   schedule:
-    - cron: '*/60 * * * *'
+    - cron: '0 12 * * MON'
 
 jobs:
   sync-labels:

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -22,7 +22,7 @@ jobs:
           - ProjectPythia/pythia-datasets
           - ProjectPythia/sphinx-pythia-theme
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: micnncim/action-label-syncer@v1
         with:
           manifest: .github/labels.yml


### PR DESCRIPTION
- Reduce cron schedule to weekly Mondays 1200 UTC. I don't see any reason this needs to be hourly. We can probably even only change this to on push to `labels.yml` contents sometime, but wanted to leave this active while we were iterating and until we change up the workflow. 

- Actions relying on node 12 (eg checkout@v2) will be deprecated. Manually bump this and we'll see if it works. I'll manually test this after merge.

Re-generated my PAT in the repo settings, so we should be good until July. I'll close #24 once confirmed this works