### PR TITLE
Try adding a new repo to the list

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -21,6 +21,7 @@ jobs:
           - ProjectPythia/pythia-foundations
           - ProjectPythia/pythia-datasets
           - ProjectPythia/sphinx-pythia-theme
+          - ProjectPythia/cmip6-cookbook
     steps:
       - uses: actions/checkout@v3
       - uses: micnncim/action-label-syncer@v1


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
Adding cmip6-cookbook to the list of repos that have their issue labels synced. That repo currently has different label colors.

If this works as expected then I'll go ahead and add more to the list.