### PR TITLE
Update CCG

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,36 +11,63 @@ hosted on the [Project Pythia Cookbooks Gallery](https://cookbooks.projectpythia
 
 Before you begin, ask yourself if the content you are developing for a cookbook would be better suited as an addition to an existing cookbook. The best place to discuss cookbook ideas is the [Project Pythia category of the Pangeo Discourse](https://discourse.pangeo.io/c/education/project-pythia/60).
 
-1. Use the template
-   1. If you don't already have a GitHub account, create one by following the [Getting Started with GitHub guide](https://foundations.projectpythia.org/foundations/getting-started-github.html)
-   1. On https://github.com/ProjectPythia/cookbook-template, click "Use this template"
-   1. Choose "Include all branches"
-   1. Create the repo under your account with a descriptive name, followed by `-cookbook` (e.g. `hydrology-cookbook`, `hpc-cookbook`, `cesm-cookbook`, etc.) by entering a name into the "Repository name" field and clicking on "Create repository from template"
-   1. Your browser should be directed to the newly created repository under your GitHub account. Under Settings, enable GitHub Pages by changing the Source from "None" to `gh-pages` and clicking on "Save"
-   1. [Clone the repo](https://foundations.projectpythia.org/foundations/github/github-cloning-forking.html) in your local workspace and `cd` into your cookbook directory
-1. Create the environment
-   1. Within `environment.yml`, change `name:` from `cookbook-dev` to `<your-cookbook-name>-dev` (e.g. `cesm-cookbook-dev`) and add all required libraries and other dependencies under `dependencies:`. Commit the changes
-   1. Create the Conda environment with `conda env create -f environment.yml`. If it crashes, try running `conda config --set channel_priority strict`
-   1. Activate your environment with `conda activate <env-name>`
-   1. Update the `.github/workflows/nightly-build.yaml` and `.github/workflows/publish-book.yaml` files to include the new name of the environment (ex. `cesm-cookbook-dev`)
-1. Add content
-   1. After [creating a new git branch](https://foundations.projectpythia.org/foundations/github/git-branches.html), edit (and duplicate as necessary) the notebook template `notebooks/notebook-template.ipynb` to add your content. Add folders to organize notebooks into sections if applicable
-   1. Add the notebooks to `_toc.yml`. See [`radar-cookbook/_toc.yml`](https://github.com/ProjectPythia/radar-cookbook/blob/main/_toc.yml) for syntax
-   1. Replace the `thumbnail.svg` with a thumbnail image relevant to your cookbook
-   1. Change `README.md` to include your cookbook title, a sentence or two describing the cookbook, and if desired embed your thumbnail image. See the [Radar Cookbook](https://github.com/ProjectPythia/radar-cookbook/blob/main/README.md) for an example
-   1. In the badge links in `README.md`, change `cookbook-template` to your cookbook repo name
-   1. Replace the `title`, `author`, `description`, `thumbnail`, and the domain and package `tags` fields in the `_config.yml` file with values relevant to your cookbook. These values will affect how information about your cookbook is displayed in the gallery.
-   1. Commit your changes with git, and [open a Pull Request](https://foundations.projectpythia.org/foundations/github/github-pull-request.html) on your cookbook repo. When you open a PR there, the github-actions bot will comment a link to a preview of your cookbook
-1. Transfer cookbook to the [ProjectPythia](https://github.com/ProjectPythia) organization
-   1. [Contact Project Pythia via the Pangeo Discourse](https://discourse.pangeo.io/c/education/project-pythia/60) (or otherwise) to let us know about your cookbook
-   1. Someone from the Pythia team will add you as a member of the ProjectPythia organization
-   1. Once you have accepted the invitation, navigate to the settings of your cookbook repository, scroll down to the Danger Zone, and click "Transfer"
-   1. Select or type "ProjectPythia", confirm, and transfer
-   1. Replace the `repository_url` in the `sphinx/config/html_theme_options` of the `_config.yml` file to point to your cookbook's new GitHub repository within the [ProjectPythia](https://github.com/ProjectPythia) organization
-   1. Make sure the workflow settings under Settings&rarr;Actions&rarr;General are set to allow Github Actions to **push** to the repository <img width="901" alt="Screenshot 2023-01-13 at 3 12 47 PM" src="https://user-images.githubusercontent.com/26660300/212428991-cd0ae2f0-73ca-40d8-b983-f122359463aa.png"> (Please reach out if you are not able to access the Settings for your repository by tagging @ProjectPythia/core)
-   1. Open issues, PRs, and continue making edits as necessary
-1. Add your cookbook to the Cookbooks Gallery!
-   1. Navigate to the [Cookbooks Gallery](https://cookbooks.projectpythia.org/)
-   1. Click the "Submit a New Cookbook" button, which will redirect you to a [new cookbook PR template](https://github.com/ProjectPythia/cookbook-gallery/issues/new?assignees=ProjectPythia%2Feducation&labels=content%2Ccookbook-gallery-submission&template=update-cookbook-gallery.yaml&title=Update+Gallery+with+new+Cookbook)
-   1. Add the root name of your cookbook repository in the relevant field and any other information you'd like the team to know
-   1. Your request will be reviewed, and you will be notified once your content has been accepted or if changes are requested
+## Data access
+
+Whenever possible, we encourage the use of freely accessible data such as the [CESM LENS data on AWS](https://registry.opendata.aws/ncar-cesm-lens/) 
+or the [CMIP6 data on GCS](https://console.cloud.google.com/marketplace/details/noaa-public/cmip6) to demonstrate your workflows.
+Otherwise, local data can be added to your Cookbook, provided it is not too large (< 50 MB). You may need to use a subset of your data.
+
+## Use the template
+
+1. If you don't already have a GitHub account, create one by following the [Getting Started with GitHub guide](https://foundations.projectpythia.org/foundations/getting-started-github.html)
+1. On https://github.com/ProjectPythia/cookbook-template, click "Use this template&rarr;Create a new repository"
+1. Give your repository a descriptive name followed by `-cookbook` (e.g., `hydrology-cookbook`, `hpc-cookbook`, `cesm-cookbook`) and a description
+1. Choose "Include all branches" and create the repository. Your browser will be directed to the newly created repository under your GitHub account
+1. Under Settings&rarr;Pages, ensure that GitHub Pages is enabled. If it is not, change the Branch from "None" to "gh-pages/(root)" and click "Save"
+1. Under Settings&rarr;Actions&rarr;General, allow Github Actions to **push** to the repository <img width="901" alt="Screenshot 2023-01-13 at 3 12 47 PM" src="https://user-images.githubusercontent.com/26660300/212428991-cd0ae2f0-73ca-40d8-b983-f122359463aa.png">
+
+Your cookbook is now ready to have content added. In the rest of this guide, we will mostly assume that you are familiar with git/GitHub. If not, we recommend reading through our [GitHub tutorials in Foundations](https://foundations.projectpythia.org/foundations/getting-started-github.html).
+
+## Set up the environment
+
+1. [Clone the repository](https://foundations.projectpythia.org/foundations/github/github-cloning-forking.html) in your local workspace
+1. Within `environment.yml`, change `name` from `cookbook-dev` to `<your-cookbook-name>-dev` (e.g. `cesm-cookbook-dev`) and add all required libraries and other dependencies under `dependencies:`. Commit the changes
+1. Create the Conda environment with `conda env create -f environment.yml`. If it crashes, try running `conda config --set channel_priority strict`
+1. Activate your environment with `conda activate <env-name>`
+1. In `.github/workflows/nightly-build.yaml`, `.github/workflows/publish-book.yaml`, and `.github/workflows/trigger-book-build.yaml`, change the `environment_name` to the name of your environment (ex. `cesm-cookbook-dev`)
+
+## Develop your cookbook
+
+To add content, you should edit (and duplicate as necessary) the notebook template `notebooks/notebook-template.ipynb`. You can add folders to organize notebooks into sections if applicable.
+Once you have a set of notebooks that you are ready to share, there are various edits that need to be made so that your cookbook is functional and polished. Here is a checklist to go through before moving on to the next step:
+
+- [ ] Add the notebooks to `_toc.yml` (the table of contents). See [`radar-cookbook/_toc.yml`](https://github.com/ProjectPythia/radar-cookbook/blob/main/_toc.yml) for syntax
+- [ ] Edit `README.md` as described in that file. This is the homepage of your cookbook, so it should be descriptive
+- [ ] In the badge links in `README.md`, change `cookbook-template` to your cookbook repo name
+- [ ] Edit `_config.yml`. These will show up on your [card in the gallery](https://cookbooks.projectpythia.org/)
+   - [ ] title
+   - [ ] author
+   - [ ] description
+   - [ ] thumbnail (not logo). You may simply replace the default `thumbnail.png` with your own image
+   - [ ] tags
+- [ ] Under the `execute` section of `_config.yml`, change `execute_notebooks` from `cache` to either `binder` to run on the Pythia Binder or `force` to run with GitHub Actions. Cookbooks that are expected to use a lot of resources should use the Pythia Binder
+- [ ] Clear all notebook outputs, since the Pythia infrastructure will execute the notebooks
+- [ ] Ensure that your cookbook successfully builds and shows the executed code
+
+## Transfer cookbook to the [ProjectPythia](https://github.com/ProjectPythia) organization
+
+1. [Contact Project Pythia via the Pangeo Discourse](https://discourse.pangeo.io/c/education/project-pythia/60) (or otherwise) to let us know about your cookbook
+1. Someone from the Pythia team will add you as a member of the ProjectPythia organization
+1. Once you have accepted the invitation, navigate to the settings of your cookbook repository, scroll down to the Danger Zone, and click "Transfer"
+1. Select or type "ProjectPythia", confirm, and transfer
+1. Replace the `repository_url` in the `sphinx/config/html_theme_options` of the `_config.yml` file to point to your cookbook's new GitHub repository within the [ProjectPythia](https://github.com/ProjectPythia) organization
+
+You will automatically retain write access to your cookbook, but if you would like to add outside collaborators to the repository, contact a member of the Pythia team to be given the Admin role on your cookbook repository.
+
+You can open issues, PRs, and continue making edits as necessary.
+
+## Add your cookbook to the Cookbooks Gallery!
+1. Navigate to the [Cookbooks Gallery](https://cookbooks.projectpythia.org/)
+1. Click the "Submit a New Cookbook" button, which will redirect you to a [new cookbook PR template](https://github.com/ProjectPythia/cookbook-gallery/issues/new?assignees=ProjectPythia%2Feducation&labels=content%2Ccookbook-gallery-submission&template=update-cookbook-gallery.yaml&title=Update+Gallery+with+new+Cookbook)
+1. Add the root name of your cookbook repository (e.g., just "cesm-cookbook", not the whole URL) and any other information you'd like the team to know
+1. Your request will be reviewed, and you will be notified once your content has been accepted or if changes are requested


### PR DESCRIPTION
This is a revision to the Cookbook Contributor's Guide. There is some reordering and clarifying, plus a list of things to check before transferring a cookbook. 

Closes #47